### PR TITLE
Fix for memory leak and analyzer warnings.

### DIFF
--- a/APNGImageSerialization/Classes/APNGImageSerialization.h
+++ b/APNGImageSerialization/Classes/APNGImageSerialization.h
@@ -91,7 +91,7 @@ UIKIT_EXTERN __attribute((overloadable)) NSData * __nullable UIImageAPNGRepresen
  *
  *  @return A new animated image
  */
-+ (UIImage *)animatedImageNamed:(NSString *)name __attribute__((objc_method_family(new)));
++ (UIImage * __nullable)animatedImageNamed:(NSString *)name __attribute__((objc_method_family(new)));
 
 @end
 

--- a/APNGImageSerialization/Classes/APNGImageSerialization.m
+++ b/APNGImageSerialization/Classes/APNGImageSerialization.m
@@ -88,12 +88,12 @@ __attribute((overloadable)) UIImage * UIAnimatedImageWithAPNGData(NSData *data, 
             NSDictionary *apngProperty = frameProperty[(__bridge NSString *)kCGImagePropertyPNGDictionary];
             NSNumber *delayTime = apngProperty[(__bridge NSString *)kCGImagePropertyAPNGUnclampedDelayTime];
 
-            if (delayTime) {
+            if (delayTime != nil) {
                 imageDuration += [delayTime doubleValue];
             }
             else {
                 delayTime = apngProperty[(__bridge NSString *)kCGImagePropertyAPNGDelayTime];
-                if (delayTime) {
+                if (delayTime != nil) {
                     imageDuration += [delayTime doubleValue];
                 }
             }

--- a/APNGImageSerialization/Classes/APNGImageSerialization.m
+++ b/APNGImageSerialization/Classes/APNGImageSerialization.m
@@ -84,7 +84,7 @@ __attribute((overloadable)) UIImage * UIAnimatedImageWithAPNGData(NSData *data, 
                 continue;
             }
 
-            NSDictionary *frameProperty = (__bridge NSDictionary *)CGImageSourceCopyPropertiesAtIndex(sourceRef, i, nil);
+            NSDictionary *frameProperty = CFBridgingRelease(CGImageSourceCopyPropertiesAtIndex(sourceRef, i, nil));
             NSDictionary *apngProperty = frameProperty[(__bridge NSString *)kCGImagePropertyPNGDictionary];
             NSNumber *delayTime = apngProperty[(__bridge NSString *)kCGImagePropertyAPNGUnclampedDelayTime];
 


### PR DESCRIPTION
Fixes a memory leak when reading APNG files.  Also fixes a couple of analyzer warnings.